### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -25,5 +25,5 @@ setControleerSensoren	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################
-VOORUIT LITERAL1
-ACHTERUIT LITERAL1
+VOORUIT	LITERAL1
+ACHTERUIT	LITERAL1


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords